### PR TITLE
Debug messages improvement

### DIFF
--- a/VTOLVR-Multiplayer/Debug.cs
+++ b/VTOLVR-Multiplayer/Debug.cs
@@ -1,0 +1,29 @@
+﻿public static class Debug
+{
+    private const string modPrefix = "[Multiplayer]";
+    public static bool ShowDebugMessages = false;
+
+    public static void Log(object message)
+    {
+        if (!ShowDebugMessages)
+            return;
+
+        UnityEngine.Debug.Log($"{modPrefix}{message}");
+    }
+
+    public static void LogWarning(object message)
+    {
+        if (!ShowDebugMessages)
+            return;
+
+        UnityEngine.Debug.LogWarning($"{modPrefix}{message}");
+    }
+
+    public static void LogError(object message)
+    {
+        if (!ShowDebugMessages)
+            return;
+
+        UnityEngine.Debug.LogError($"{modPrefix}{message}");
+    }
+}

--- a/VTOLVR-Multiplayer/DiscordRadioManager.cs
+++ b/VTOLVR-Multiplayer/DiscordRadioManager.cs
@@ -25,7 +25,7 @@ public static class DiscordRadioManager
     public static string freqLabelTableNetworkString = "122.8";
     public static void start()
     {
-        UnityEngine.Debug.Log("loading discord");
+        Debug.Log("loading discord");
         var dllDirectory = @"VTOLVR_ModLoader\mods\Multiplayer\discordsdk";
         Environment.SetEnvironmentVariable("PATH", Environment.GetEnvironmentVariable("PATH") + ";" + dllDirectory);
         var clientID = Environment.GetEnvironmentVariable("DISCORD_CLIENT_ID");
@@ -33,7 +33,7 @@ public static class DiscordRadioManager
         {
             clientID = "759675844971986975";
         }
-        connectedToDiscord = true; 
+        connectedToDiscord = true;
         PersonaName = Steamworks.SteamFriends.GetPersonaName();
 
         radioFreq = 0;
@@ -61,7 +61,7 @@ public static class DiscordRadioManager
             userID = currentUser.Id;
         };
 
-  
+
     }
 
     public static void reloadFrequencyTextFiles()
@@ -85,14 +85,14 @@ public static class DiscordRadioManager
             readText = System.IO.File.ReadAllText(dllDirectory + @"\freq.txt");
             string[] values = readText.Split(',');
             frequencyTable.Add(values);
-            UnityEngine.Debug.Log("loading freqs");
+            Debug.Log("loading freqs");
             freqTableNetworkString += "," + readText;
         }
 
         if (System.IO.File.Exists(dllDirectory + @"\freqlabels.txt"))
         {
             readText = System.IO.File.ReadAllText(dllDirectory + @"\freqlabels.txt");
-            UnityEngine.Debug.Log("loading freqlabels");
+            Debug.Log("loading freqlabels");
             string[] values = readText.Split(',');
             frequencyTableLabels.Add(values);
             freqLabelTableNetworkString += "," + readText;
@@ -151,7 +151,7 @@ public static class DiscordRadioManager
         reloadFrequencyTextFiles();
         connected = false;
         radioFreq = 0;
-    
+
         lobbyManager.DisconnectVoice(lobbyID, (result) =>
         {
             if (result == Discord.Result.Ok)
@@ -227,7 +227,7 @@ public static class DiscordRadioManager
     {
         if (!connectedToDiscord)
             return;
-     
+
 
         if (!steamIDtoFreq.ContainsKey(name))
             steamIDtoFreq.Add(name, 0);
@@ -238,7 +238,7 @@ public static class DiscordRadioManager
     {
         if (!connectedToDiscord)
             return;
-        // UnityEngine.Debug.Log("setting freq of player "+ name + "to"+ freq);
+        // Debug.Log("setting freq of player "+ name + "to"+ freq);
         if (!steamIDtoFreq.ContainsKey(name))
             steamIDtoFreq.Add(name, freq);
         else
@@ -316,7 +316,7 @@ public static class DiscordRadioManager
             {
                 if (steamIDtoFreq.ContainsKey(play.nameTag))
                 {
-                    if(steamIDtoFreq[play.nameTag] == 9999)
+                    if (steamIDtoFreq[play.nameTag] == 9999)
                     {
                         mutePlayer(play, play.nameTag, false);
                         FlightLogger.Log("command");
@@ -324,7 +324,7 @@ public static class DiscordRadioManager
                     else
                     if (steamIDtoFreq[play.nameTag] != radioFreq)
                     {
-                        mutePlayer(play,play.nameTag, true);
+                        mutePlayer(play, play.nameTag, true);
                     }
                     else
                     {
@@ -335,7 +335,7 @@ public static class DiscordRadioManager
         }
     }
 
-    public static void mutePlayer(PlayerManager.Player play,string name, bool state)
+    public static void mutePlayer(PlayerManager.Player play, string name, bool state)
     {
         if (!connectedToDiscord)
             return;
@@ -346,19 +346,19 @@ public static class DiscordRadioManager
 
             if (play.discordID == ids)
             {
-               
+
                 if (userID != ids)
                 {
                     if (state)
                     {
-                         discord.GetVoiceManager().SetLocalVolume(ids, 0);
+                        discord.GetVoiceManager().SetLocalVolume(ids, 0);
                         //discord.GetVoiceManager().SetLocalMute(discordid, true);
                     }
 
                     else
                     {
-                    //    discord.GetVoiceManager().SetLocalMute(discordid, false);
-                    discord.GetVoiceManager().SetLocalVolume(ids, 100);
+                        //    discord.GetVoiceManager().SetLocalMute(discordid, false);
+                        discord.GetVoiceManager().SetLocalVolume(ids, 100);
                     }
 
                 }

--- a/VTOLVR-Multiplayer/Messages/Message.cs
+++ b/VTOLVR-Multiplayer/Messages/Message.cs
@@ -63,22 +63,22 @@ public class PacketCompressedBatch : Packet
         messages.Add(msg);
         MemoryStream memoryStream = new MemoryStream();
         binaryFormatter.Serialize(memoryStream, msg);
-        //UnityEngine.Debug.Log("buffer " + messagesNum);
+        //Debug.Log("buffer " + messagesNum);
         /*foreach( byte b in memoryStream.ToArray())
         {
             uncompressedData.Add(b);
         }*/
         uncompressedData.AddRange(memoryStream.ToArray());
         messagesSize[messagesNum] = (int)memoryStream.Length;
-        //UnityEngine.Debug.Log("serlized size" + messagesSize[messagesNum]);
+        //Debug.Log("serlized size" + messagesSize[messagesNum]);
         messagesNum += 1;
 
-        // UnityEngine.Debug.Log("uncompressedData size" + uncompressedData.Count);
+        // Debug.Log("uncompressedData size" + uncompressedData.Count);
     }
     public void prepareForSend()
     {
-        // UnityEngine.Debug.Log("messagesNum " + messagesNum);
-        //UnityEngine.Debug.Log("messagesNumlist " + messages.Count);
+        // Debug.Log("messagesNum " + messagesNum);
+        //Debug.Log("messagesNumlist " + messages.Count);
         CompressMessages();
     }
 
@@ -107,9 +107,9 @@ public class PacketCompressedBatch : Packet
     public void generateMessageList()
     {
 
-        // UnityEngine.Debug.Log("post uncompressedData size" + decomperessedBuffer.Length);
+        // Debug.Log("post uncompressedData size" + decomperessedBuffer.Length);
         messages.Clear();
-        // UnityEngine.Debug.Log("messagesNum " + messagesNum);
+        // Debug.Log("messagesNum " + messagesNum);
         int index = 0;
         for (int i = 0; i < messagesNum; i++)
         {

--- a/VTOLVR-Multiplayer/ModVersionString.cs
+++ b/VTOLVR-Multiplayer/ModVersionString.cs
@@ -1,5 +1,5 @@
 ﻿static class ModVersionString
 {
     public static string ReleaseBranch = "Release";
-    public static string ModVersionNumber = "2.9.0";
+    public static string ModVersionNumber = "3.0.1";
 }

--- a/VTOLVR-Multiplayer/Multiplayer.cs
+++ b/VTOLVR-Multiplayer/Multiplayer.cs
@@ -108,7 +108,7 @@ public class Multiplayer : VTOLMOD
         }
         _instance = this;
         Networker.SetMultiplayerInstance(this);
-        
+
     }
     public static void callback()
     {
@@ -122,7 +122,7 @@ public class Multiplayer : VTOLMOD
     {
         Log($"VTOL VR Multiplayer v{ ModVersionString.ModVersionNumber } - branch: { ModVersionString.ReleaseBranch }");
 
-         GameSettings.SetGameSettingValue("USE_OVERCLOUD", false, true);
+        GameSettings.SetGameSettingValue("USE_OVERCLOUD", false, true);
 #if DEBUG
         Log("Running in Debug Mode");
 #else
@@ -142,7 +142,7 @@ public class Multiplayer : VTOLMOD
         base.ModLoaded();
         CreateUI();
         gameObject.AddComponent<Networker>();
-     
+
         debugLog_Settings(debugLogs);
     }
 
@@ -205,8 +205,8 @@ public class Multiplayer : VTOLMOD
 
         settings.CreateCustomLabel("Fog strength");
         fog_changed += fog_Settings;
-        settings.CreateFloatSetting("Default = 0.0f", fog_changed, 0.0f,0.0f,1.0f);
-       
+        settings.CreateFloatSetting("Default = 0.0f", fog_changed, 0.0f, 0.0f, 1.0f);
+
         /*spawnRemainingPlayersAtAirBase_changed += spawnRemainingPlayersAtAirBase_Setting;
         settings.CreateCustomLabel("Spawn players at airbase if there are no wingmen available.");
         settings.CreateBoolSetting("Default = False", spawnRemainingPlayersAtAirBase_changed, spawnRemainingPlayersAtAirBase);*/
@@ -274,11 +274,11 @@ public class Multiplayer : VTOLMOD
     {
         debugLogs = newval;
         if (ModVersionString.ReleaseBranch == "Release")
-            Debug.logger.logEnabled = newval;
+            Debug.ShowDebugMessages = newval;
         else
         {
-            if (Debug.logger.logEnabled != true)
-                Debug.logger.logEnabled = true;
+            if (Debug.ShowDebugMessages != true)
+                Debug.ShowDebugMessages = true;
         }
     }
 
@@ -316,9 +316,9 @@ public class Multiplayer : VTOLMOD
     }
     public void ptt_Settings(bool newval)
     {
-        ptt = newval; 
+        ptt = newval;
     }
-    
+
     void OnGUI()//the 2d ping display, feel free to move elsewhere
     {
         if (displayPing)
@@ -365,7 +365,7 @@ public class Multiplayer : VTOLMOD
         {
             case VTOLScenes.ReadyRoom:
                 CreateUI();
-             
+
                 break;
             case VTOLScenes.Akutan:
                 Log("Map Loaded from vtol scenes akutan");
@@ -380,13 +380,13 @@ public class Multiplayer : VTOLMOD
                 StartCoroutine(PlayerManager.MapLoaded());
                 break;
             case VTOLScenes.CustomMapBase_OverCloud:
-                   Log("Map Loaded from vtol scenes custom map base");
+                Log("Map Loaded from vtol scenes custom map base");
                 waitingForJoin = null;
                 DestroyLoadingSceneObjects();
                 StartCoroutine(PlayerManager.MapLoaded());
                 break;
             case VTOLScenes.LoadingScene:
-                
+
                 if (playingMP)
                 {
                     Log("Create Loading Scene");
@@ -766,7 +766,7 @@ public class Multiplayer : VTOLMOD
             PilotSaveManager.currentCampaign + "\n" +
             PilotSaveManager.currentVehicle);
 
-       
+
     }
 
     public void Host()
@@ -815,7 +815,7 @@ public class Multiplayer : VTOLMOD
 
     public void Join()
     {
-      
+
         playingMP = true;
         if (Networker.hostID == new Steamworks.CSteamID(0) && waitingForJoin == null)
         {

--- a/VTOLVR-Multiplayer/VTOLVR-Multiplayer.csproj
+++ b/VTOLVR-Multiplayer/VTOLVR-Multiplayer.csproj
@@ -139,6 +139,7 @@
     <Compile Include="AIManager.cs" />
     <Compile Include="AvatarManager.cs" />
     <Compile Include="CustomCockpit\CustomCockpitAPI.cs" />
+    <Compile Include="Debug.cs" />
     <Compile Include="DiscordRadioManager.cs" />
     <Compile Include="Discord\ActivityManager.cs" />
     <Compile Include="Discord\Constants.cs" />


### PR DESCRIPTION
This PR makes it so the multiplayer mod uses its own `Debug` class instead of Unity's `Debug` class. That means you can disable debug messages just for the multiplayer mod but not for everything else.

This pull request also updates the `ModVersionNumber` to 3.0.1