### PR TITLE
Fixed Issue with discord SDK and incorrect folder name

### DIFF
--- a/VTOLVR-Multiplayer/DiscordRadioManager.cs
+++ b/VTOLVR-Multiplayer/DiscordRadioManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 
 public static class DiscordRadioManager
 {
+    private const string discordFolder = "discordsdk";
     public static Discord.Discord discord;
     public static bool connectedToDiscord;
 
@@ -25,9 +26,12 @@ public static class DiscordRadioManager
     public static string freqLabelTableNetworkString = "122.8";
     public static void start()
     {
-        Debug.Log("loading discord");
-        var dllDirectory = @"VTOLVR_ModLoader\mods\Multiplayer\discordsdk";
+        Debug.Log("Loading DiscordRadioManager");
+        string modFolder = Multiplayer._instance.ThisMod.ModFolder;
+        string vtolFolder = System.IO.Directory.GetCurrentDirectory() + "\\";
+        string dllDirectory = modFolder.Replace(vtolFolder, string.Empty) + $"\\{discordFolder}";
         Environment.SetEnvironmentVariable("PATH", Environment.GetEnvironmentVariable("PATH") + ";" + dllDirectory);
+
         var clientID = Environment.GetEnvironmentVariable("DISCORD_CLIENT_ID");
         if (clientID == null)
         {

--- a/VTOLVR-Multiplayer/Multiplayer.cs
+++ b/VTOLVR-Multiplayer/Multiplayer.cs
@@ -121,6 +121,7 @@ public class Multiplayer : VTOLMOD
     public override void ModLoaded()
     {
         Log($"VTOL VR Multiplayer v{ ModVersionString.ModVersionNumber } - branch: { ModVersionString.ReleaseBranch }");
+        Start();
 
         GameSettings.SetGameSettingValue("USE_OVERCLOUD", false, true);
 #if DEBUG


### PR DESCRIPTION
If the user tries to manually extract the multiplayer mod and the folder name doesn't match `Multiplayer`. There will be an error when loading with the discord sdk.

The way I got around this is by using the mod loaders `Mod.ThisMod.ModFolder` then removing the start of the string using `Directory.GetCurrentDirectory()` 

For some reason, I also had to call `Multiplayer.Start()`. Which I thought unity would be calling first before `VTOLMOD.ModLoaded()`