### PR TITLE
Changed the "tooltip" message on the buttons

### DIFF
--- a/VTOLVR-Multiplayer/Multiplayer.cs
+++ b/VTOLVR-Multiplayer/Multiplayer.cs
@@ -546,6 +546,11 @@ public class Multiplayer : VTOLMOD
         mpButtonF.name = "MPButtonf";
         mpButtonF.GetComponent<RectTransform>().localPosition = new Vector3(0, -325);
         mpButtonF.GetComponent<RectTransform>().sizeDelta = new Vector2(70, 206.7f);
+
+        VRInteractable mpInteractableF = mpButtonF.GetComponent<VRInteractable>();
+        if (mpInteractableF != null)
+            mpInteractableF.interactableName = "Friends";
+        
         mpButtonF.GetComponentInChildren<Text>().text = "Friend";
         mpButtonF.GetComponent<Image>().color = Color.cyan;
         mpButtonF.GetComponent<Button>().onClick = new Button.ButtonClickedEvent();
@@ -554,7 +559,7 @@ public class Multiplayer : VTOLMOD
         if (UpToDate)
         {
             mpButton.GetComponent<Image>().color = Color.cyan;
-            mpInteractable.interactableName = "Multiplayer";
+            mpInteractable.interactableName = "Lobby";
         }
         else
         {


### PR DESCRIPTION
The Lobby feature looks great, just thought I could fix some minor issue with the buttons "tool tips". This is how they where

![20210603115234_1](https://user-images.githubusercontent.com/33008390/120633830-801aa100-c462-11eb-8b5b-394ef7c4980f.jpg)

Now Friend says `Friends` and Lobby says `Lobby`
